### PR TITLE
scssPreprocessor config should can be optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function formattedScssMessage(error) {
  * @param helper {Object} Karma's helper functions.
  */
 function createScssPreprocessor(args, config, logger, helper) {
+  config = config || {};
 
   var log = logger.create('preprocessor.scss');
 


### PR DESCRIPTION
Since you forget to give `config` a default value `{}`, it will be `undefined` by default, then `config.options || {}` will throw an error, so I have to add an empty object in `karma.conf.js` like this:

``` js
{
  preprocessors : {
    '**/*.scss' : [ 'scss' ]
  } ,
  scssPreprocessor:{} // empty, but it should  can be ignore
}
```

Add a default value `{}` to `config` can fix that.
