### PR TITLE
Swap Node Sass (deprecated) for Dart Sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ karma-scss-preprocessor
 [![devDependencies Status](https://david-dm.org/amercier/karma-scss-preprocessor/dev-status.svg)](https://david-dm.org/amercier/karma-scss-preprocessor?type=dev)
 [![peerDependencies Status](https://david-dm.org/amercier/karma-scss-preprocessor/peer-status.svg)](https://david-dm.org/amercier/karma-scss-preprocessor?type=peer)
 
-> Karma preprocessor to compile Sass files on the fly with [node-sass](https://www.npmjs.com/package/node-sass).
+> Karma preprocessor to compile Sass files on the fly with [sass](https://www.npmjs.com/package/sass).
 > In contrast of [karma-sass-preprocessor](https://www.npmjs.com/package/karma-sass-preprocessor),
 > it does not write any intermediate file to the disk, and does not use any
 > [Gulp](http://gulpjs.com/) plugin.
@@ -20,17 +20,17 @@ Installation
 ------------
 
 ```bash
-npm install karma-scss-preprocessor node-sass --save-dev
+npm install karma-scss-preprocessor sass --save-dev
 ```
 
-Note: since v2.0, [node-sass](https://www.npmjs.com/package/node-sass) is used
+Note: since v2.0, [sass](https://www.npmjs.com/package/sass) is used
 as a [peer dependency](https://docs.npmjs.com/files/package.json#peerdependencies).
 That is why you need to install it along with this module.
 
 Configuration
 -------------
 
-See [node-sass options](https://www.npmjs.com/package/node-sass) for more
+See [sass options](https://www.npmjs.com/package/sass) for more
 details.
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "karma-scss-preprocessor",
   "version": "4.0.0",
-  "description": "Karma preprocessor to compile SCSS on the fly with node-sass",
+  "description": "Karma preprocessor to compile SCSS on the fly with sass",
   "license": "ISC",
   "repository": "amercier/karma-scss-preprocessor",
   "author": "Alex Mercier <pro.alexandre.mercier@gmail.com> (http://amercier.com)",
@@ -22,7 +22,7 @@
     "karma-preprocessor",
     "sass",
     "scss",
-    "node-sass"
+    "sass"
   ],
   "dependencies": {
     "chalk": "^2.4.1",
@@ -30,7 +30,7 @@
     "strip-ansi": "^5.0.0"
   },
   "peerDependencies": {
-    "node-sass": ">= 3.x"
+    "sass": ">= 1.x"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -50,7 +50,7 @@
     "karma-mocha": "^1.3.0",
     "karma-phantomjs-launcher": "^1.0.4",
     "mocha": "^5.2.0",
-    "node-sass": "^4.10.0",
+    "sass": "^1.32.6",
     "npm": "^6.4.1",
     "nyc": "^13.1.0",
     "phantomjs-prebuilt": "^2.1.16",

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,4 +1,4 @@
-import sass from 'node-sass';
+import sass from 'sass';
 import path from 'path';
 import chalk from 'chalk';
 import { clone, merge } from 'lodash';
@@ -24,7 +24,7 @@ function formattedScssMessage(error, file) {
 function createScssPreprocessor(args, config = {}, logger) {
   const log = logger.create('preprocessor.scss');
 
-  // Options. See https://www.npmjs.com/package/node-sass for details
+  // Options. See https://www.npmjs.com/package/sass for details
   const options = merge({
     sourceMap: false,
     transformPath(filepath) {
@@ -52,7 +52,7 @@ function createScssPreprocessor(args, config = {}, logger) {
       opts.omitSourceMapUrl = true;
     }
 
-    // Compile using node-sass (synchronously)
+    // Compile using sass (synchronously)
     try {
       opts.file = file.originalPath;
       result = sass.renderSync(opts);


### PR DESCRIPTION
Hi 👋 thanks for your work on `karma-scss-preprocessor`! Would you be open to a pull request which switches from [node-sass](https://www.npmjs.com/package/node-sass) (deprecated) to [dart-sass](https://www.npmjs.com/package/sass)?

node-sass: https://www.npmjs.com/package/node-sass
dart-sass: https://www.npmjs.com/package/sass

Dart Sass supports a JavaScript API that's fully compatible with Node
Sass, with a few exceptions:
- no `precision` option
- no `sourceComments` option
- the `outputStyle` option is limited to "expanded" and "compressed"

So while this is a breaking change, it would be possible to support
both Node Sass (deprecated) and Dart Sass by adding a new parameter
to `karma-scss-preprocessor` which accepts a Sass implementation.
Since Node Sass is deprecated however it may be better to switch
without adding a new option.